### PR TITLE
lazy_loader 0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "lazy_loader" %}
-{% set version = "0.3" %}
-
+{% set version = "0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37
+  sha256: 47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1
 
 build:
   number: 0
@@ -18,29 +17,32 @@ requirements:
   host:
     - pip
     - python
-    - flit-core >=3.8,<4
+    - setuptools
+    - wheel
   run:
     - python
+    - importlib_metadata  # [py<38]
+    - packaging
 
 test:
   imports:
     - lazy_loader
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest --pyargs lazy_loader
 
 about:
   home: https://scientific-python.org/specs/spec-0001/
   summary: Easily load subpackages and functions on demand
-  dev_url: https://github.com/scientific-python/lazy-loader
+  dev_url: https://github.com/scientific-python/lazy_loader
   license: BSD-3-Clause
   license_file: LICENSE.md
   license_family: BSD
   description: |
-    `lazy-loader` makes it easy to load subpackages and functions on demand.
-
-    PyPI: [https://pypi.org/project/lazy_loader/](https://pypi.org/project/lazy_loader/)
+    'lazy-loader' makes it easy to load subpackages and functions on demand.
   doc_url: https://github.com/scientific-python/lazy_loader
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:**

### Links

- [PKG-5073](https://anaconda.atlassian.net/browse/PKG-5073)
- release-diff: https://github.com/scientific-python/lazy_loader/compare/v0.3...v0.4
- changelog: https://github.com/scientific-python/lazy_loader/blob/main/CHANGELOG.md
- requirements-tagged:
  - https://github.com/scientific-python/lazy_loader/blob/v0.4/pyproject.toml


### Explanation of changes:

- Replace `flit-core` by `setuptools` in `host`
- Add `packaging` to run, see https://github.com/scientific-python/lazy_loader/blob/v0.4/lazy_loader/__init__.py#L272
- Run pytest

### Notes:

- `scikit-image 0.23.2` requires **lazy_loader >=0.4** https://github.com/scikit-image/scikit-image/blob/v0.23.2/pyproject.toml#L35


[PKG-5073]: https://anaconda.atlassian.net/browse/PKG-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ